### PR TITLE
BREAKING CHANGE: Enforce new authentication - same network (no auth) or fresh TOTP (device online)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The **Re4 Job File API** provides endpoints to process job files, including vect
 ### Authentication Requirements
 
 - **User Passcode**: Required for all API endpoints. This can be found under your username after logging into the web interface (e.g., [https://beta.fslaser.com](https://beta.fslaser.com)). Note that for different website you will get a different user passcode.
-- **Device Access Code**: Required for all API endpoints. This is displayed on the device's touchscreen and is unique to each machine.
+- **Device ID**: Required for all API endpoints. This is a unique identifier for each machine.
   - The device must be added to the device list on the target API website
   - The device must be connected to the website
   - The generated `.lap` file will only work with the correct device
@@ -90,7 +90,7 @@ The **Re4 Job File API** provides endpoints to process job files, including vect
 **Request Parameters**:
 
 - **Form Fields**:
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
 
 **Response**:
 - Returns JSON data containing workspace bounds information for the device
@@ -109,7 +109,7 @@ The **Re4 Job File API** provides endpoints to process job files, including vect
 
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/get-workspace-bounds" \
-  -F "device_access_code=my-device-access-code"
+  -F "device_id=AE356O3E89D"
 ```
 
 ### Process Vector Job (SVG)
@@ -124,7 +124,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-workspace-bounds" \
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -138,7 +138,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-workspace-bounds" \
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code" \
+  -F "device_id=AE356O3E89D" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -162,7 +162,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -177,7 +177,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code" \
+  -F "device_id=AE356O3E89D" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -200,7 +200,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `transform_params` (str): A JSON string with transformation parameters (`[sx, shy, shx, sy, tx, ty]`) which operates in mm space.
     - `sx`: Scale factor in the x-direction
     - `shy`: Shear factor in the y-direction
@@ -217,7 +217,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
 #### Example CURL (standard-png-lap)
 
 ```bash
-curl -X POST "https://beta.fslaser.com/api/jobs/standard-png-lap"   -F "pass_code=my-pass-code"   -F "device_access_code=my-device-access-code"   -F "png_file=@path/to/your/image.png"   -F "json_file=@path/to/your/color_settings.json"   -F "transform_params=[0.1, 0, 0, 0.1, 20.0, 15.25]"   --output generated_file.lap
+curl -X POST "https://beta.fslaser.com/api/jobs/standard-png-lap"   -F "pass_code=my-pass-code"   -F "device_id=AE356O3E89D"   -F "png_file=@path/to/your/image.png"   -F "json_file=@path/to/your/color_settings.json"   -F "transform_params=[0.1, 0, 0, 0.1, 20.0, 15.25]"   --output generated_file.lap
 ```
 
 **NOTE**:
@@ -312,7 +312,7 @@ The API assumes all input images are at 96 DPI (dots per inch) when converting t
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `color` (str): Stroke color for the vector paths.
 - **Files**:
   - `npz_file`: The NPZ file containing vector paths.
@@ -321,7 +321,7 @@ The API assumes all input images are at 96 DPI (dots per inch) when converting t
 #### Example CURL (standard-npz-paths2d-lap)
 
 ```bash
-curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "pass_code=my-pass-code"   -F "device_access_code=my-device-access-code"   -F "npz_file=@path/to/your/file.npz"   -F "json_file=@path/to/your/color_settings.json"   -F "color=#FF5733"   --output generated_file.lap
+curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "pass_code=my-pass-code"   -F "device_id=AE356O3E89D"   -F "npz_file=@path/to/your/file.npz"   -F "json_file=@path/to/your/color_settings.json"   -F "color=#FF5733"   --output generated_file.lap
 ```
 
 ### Process Points (NPZ)
@@ -336,7 +336,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
 - **Files**:
   - `npz_file`: The NPZ file containing vector paths.
   - `json_file`: A JSON file containing color settings.
@@ -344,7 +344,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "
 #### Example CURL (standard-npz-points2d-lap)
 
 ```bash
-curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F "pass_code=my-pass-code"   -F "device_access_code=my-device-access-code"   -F "npz_file=@path/to/your/file.npz"   -F "json_file=@path/to/your/color_settings.json"   --output generated_file.lap
+curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F "pass_code=my-pass-code"   -F "device_id=AE356O3E89D"   -F "npz_file=@path/to/your/file.npz"   -F "json_file=@path/to/your/color_settings.json"   --output generated_file.lap
 ```
 
 ### Process GVDesign Job
@@ -359,7 +359,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F 
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -373,7 +373,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F 
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code" \
+  -F "device_id=AE356O3E89D" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -395,7 +395,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -409,7 +409,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code" \
+  -F "device_id=AE356O3E89D" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -435,7 +435,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
-  - `device_access_code` (str): Device access code obtained from device touchscreen.
+  - `device_id` (str): Device ID for authentication.
 - **Files**:
   - `lap_file`: The `.lap` file to execute.
 
@@ -444,7 +444,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/api-run-lap-job" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code" \
+  -F "device_id=AE356O3E89D" \
   -F "lap_file=@path/to/your/job.lap"
 ```
 
@@ -460,14 +460,14 @@ curl -X POST "https://beta.fslaser.com/api/jobs/api-run-lap-job" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
 
 #### Example CURL (api-stop-job)
 
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/api-stop-job" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code"
+  -F "device_id=AE356O3E89D"
 ```
 
 ### Query Job Status
@@ -482,14 +482,14 @@ curl -X POST "https://beta.fslaser.com/api/jobs/api-stop-job" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
 
 #### Example CURL (api-query-job-status)
 
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/api-query-job-status" \
   -F "pass_code=my-pass-code" \
-  -F "device_access_code=my-device-access-code"
+  -F "device_id=AE356O3E89D"
 ```
 
 ### Capture Image
@@ -504,7 +504,7 @@ Captures an image from the specified device.
 
 The request should be `multipart/form-data` and include the following fields:
 
-- `device_access_code` (string, required): The access code for the device.
+- `device_id` (string, required): The id (MAC address) for the device.
 - `pass_code` (string, required): The user's pass code.
 - `is_corrected` (boolean, optional): Specifies whether the captured image should be corrected. If `true`, the corrected image is returned. Otherwise, the original image is returned. Defaults to `false` if not specified.
 
@@ -538,7 +538,7 @@ The request should be `multipart/form-data` and include the following fields:
 ```bash
 curl -X POST "YOUR_SERVER_URL/api/jobs/capture-image" \
      -F "pass_code=your_pass_code" \
-     -F "device_access_code=your_device_access_code" \
+     -F "device_id=your_device_id" \
      -F "is_corrected=true" \
      --output captured_image.jpg
 ```
@@ -557,14 +557,14 @@ curl -X POST "YOUR_SERVER_URL/api/jobs/capture-image" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `x_mm` (float, optional): X position in millimeters. Can be `null` to skip moving along X.
   - `y_mm` (float, optional): Y position in millimeters. Can be `null` to skip moving along Y.
   - `z_mm` (float, optional): Z position in millimeters. Can be `null` to skip moving along Z.
 
 > **Note:** At least one of `x_mm`, `y_mm`, or `z_mm` must be provided (not `null`). If a value is `null`, the gantry will not move along that axis.
 
-This endpoint allows you to move the gantry of a device to a specific position. If you do not wish to move along a particular axis, set its value to `null` or omit it. The endpoint requires a valid device access code for authentication and device selection.
+This endpoint allows you to move the gantry of a device to a specific position. If you do not wish to move along a particular axis, set its value to `null` or omit it. The endpoint requires a valid device ID for authentication and device selection.
 
 #### Example CURL (gantry-move)
 
@@ -573,7 +573,7 @@ curl -X POST "https://your-server/api/jobs/gantry-move" \
   -F "x_mm=100.0" \
   -F "y_mm=50.0" \
   -F "z_mm=" \
-  -F "device_access_code=YOUR_DEVICE_ACCESS_CODE"
+  -F "device_id=AE356O3E89D"
 ```
 
 ### Success Response
@@ -614,7 +614,7 @@ curl -X POST "https://your-server/api/jobs/gantry-move" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `gpio_pin` (int): The pin to set.
 
 #### Example cURL (set-gpio)
@@ -622,7 +622,7 @@ curl -X POST "https://your-server/api/jobs/gantry-move" \
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
   -F "gpio_pin=1" \
-  -F "device_access_code=YOUR_DEVICE_ACCESS_CODE"
+  -F "device_id=AE356O3E89D"
 ```
 
 **Success Response**:
@@ -644,7 +644,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `gpio_pin` (int): The pin to clear.
 
 #### Example CURL (clear-gpio)
@@ -652,7 +652,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
   -F "gpio_pin=1" \
-  -F "device_access_code=YOUR_DEVICE_ACCESS_CODE"
+  -F "device_id=AE356O3E89D"
 ```
 
 **Success Response**:
@@ -674,7 +674,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `gpio_pin` (int): The pin to get.
 
 #### Example CURL (get-gpio)
@@ -682,7 +682,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
   -F "gpio_pin=1" \
-  -F "device_access_code=YOUR_DEVICE_ACCESS_CODE"
+  -F "device_id=AE356O3E89D"
 ```
 
 **Success Response**:
@@ -711,7 +711,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `gpio_pin` (int): The pin to set.
   - `blink_duration_ms` (int, optional): The duration of the blink in milliseconds. Default is 1000, if not specified.
 
@@ -721,7 +721,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
 curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
   -F "gpio_pin=1" \
   -F "blink_duration_ms=250" \
-  -F "device_access_code=YOUR_DEVICE_ACCESS_CODE"
+  -F "device_id=AE356O3E89D"
 ```
 
 **Success Response**:
@@ -743,7 +743,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
 
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
-  - `device_access_code` (str): Device access code obtained from RE4 or the device touchscreen.
+  - `device_id` (str): Device ID for authentication.
   - `gpio_command` (str): The command to send.
 
 #### Example cURL (send-gpio)
@@ -751,7 +751,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/send-gpio" \
   -F "gpio_command=set pin1" \
-  -F "device_access_code=YOUR_DEVICE_ACCESS_CODE"
+  -F "device_id=AE356O3E89D"
 ```
 
 **Success Response**:
@@ -792,7 +792,7 @@ python standard_svg.py
 Before running any script, make sure to:
 
 1. Update the `pass_code` with your user passcode from the website
-2. Update the `device_access_code` with the code from your device's touchscreen
+2. Update the `device_id` with your device's unique ID
 3. Set the correct paths for input and output files
 
 ---

--- a/README.md
+++ b/README.md
@@ -51,9 +51,23 @@ The **Re4 Job File API** provides endpoints to process job files, including vect
   - The device must be connected to the website
   - The generated `.lap` file will only work with the correct device
 - **Device Auth Code**: Required for most API endpoints (except `get-workspace-bounds`). This is a time-based one-time password (TOTP) that must be fetched from the device's `/2fa` endpoint.
-  - Obtained by making a GET request to `http://{device_ip}/2fa` 
-  - The response contains a JSON object with a `totp` field containing the auth code
+  - **Network Requirement**: The TOTP endpoint requires direct network access to the device's IP address. Clients must be on the same local network as the device or have VPN/routing access to reach the device's subnet.
+  - Obtained by making a POST request to `https://{device_ip}/2fa` or `http://{device_ip}/2fa`
+  - **Note**: Both HTTP and HTTPS work, but HTTPS requires SSL verification to be disabled (`verify=False` in Python, `-k` flag in curl)
+  - The response contains a JSON object with a `success` field and nested `totp` object containing the auth code
+  - Access the auth code via `response["totp"]["totp"]` after checking `response["success"]`
   - This code changes periodically and must be fetched fresh for each API call
+  - **Example TOTP Response**:
+    ```json
+    {
+      "success": true,
+      "totp": {
+        "totp": "565244",
+        "expire_time": 1757444100,
+        "expire_time_str": "2025-09-09 11:55:00"
+      }
+    }
+    ```
 
 ### File Requirements
 
@@ -144,7 +158,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-workspace-bounds" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -185,7 +199,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -229,7 +243,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-png-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "png_file=@path/to/your/image.png" \
   -F "json_file=@path/to/your/color_settings.json" \
   -F "transform_params=[0.1, 0, 0, 0.1, 20.0, 15.25]" \
@@ -341,7 +355,7 @@ The API assumes all input images are at 96 DPI (dots per inch) when converting t
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "npz_file=@path/to/your/file.npz" \
   -F "json_file=@path/to/your/color_settings.json" \
   -F "color=#FF5733" \
@@ -372,7 +386,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "npz_file=@path/to/your/file.npz" \
   -F "json_file=@path/to/your/color_settings.json" \
   --output generated_file.lap
@@ -406,7 +420,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -444,7 +458,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -481,7 +495,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/api-run-lap-job" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "lap_file=@path/to/your/job.lap"
 ```
 
@@ -506,7 +520,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/api-run-lap-job" \
 curl -X POST "https://beta.fslaser.com/api/jobs/api-stop-job" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
 ```
 
 ### Query Job Status
@@ -530,7 +544,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/api-stop-job" \
 curl -X POST "https://beta.fslaser.com/api/jobs/api-query-job-status" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
 ```
 
 ### Capture Image
@@ -581,7 +595,7 @@ The request should be `multipart/form-data` and include the following fields:
 curl -X POST "YOUR_SERVER_URL/api/jobs/capture-image" \
      -F "pass_code=your_pass_code" \
      -F "device_id=your_device_id" \
-     -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+     -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
      -F "is_corrected=true" \
      --output captured_image.jpg
 ```
@@ -616,7 +630,7 @@ This endpoint allows you to move the gantry of a device to a specific position. 
 curl -X POST "https://your-server/api/jobs/gantry-move" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "x_mm=100.0" \
   -F "y_mm=50.0" \
   -F "z_mm=" \
@@ -670,7 +684,7 @@ curl -X POST "https://your-server/api/jobs/gantry-move" \
 curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "gpio_pin=1"
 ```
 
@@ -703,7 +717,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
 curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "gpio_pin=1"
 ```
 
@@ -736,7 +750,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
 curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "gpio_pin=1"
 ```
 
@@ -777,7 +791,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
 curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "gpio_pin=1" \
   -F "blink_duration_ms=250"
 ```
@@ -811,7 +825,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
 curl -X POST "https://beta.fslaser.com/api/jobs/send-gpio" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
-  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "device_auth_code=$(curl -s -k https://192.168.1.100/2fa | jq -r '.totp.totp')" \
   -F "gpio_command=set pin1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The **Re4 Job File API** provides endpoints to process job files, including vect
   - The device must be added to the device list on the target API website
   - The device must be connected to the website
   - The generated `.lap` file will only work with the correct device
+- **Device Auth Code**: Required for most API endpoints (except `get-workspace-bounds`). This is a time-based one-time password (TOTP) that must be fetched from the device's `/2fa` endpoint.
+  - Obtained by making a GET request to `http://{device_ip}/2fa` 
+  - The response contains a JSON object with a `totp` field containing the auth code
+  - This code changes periodically and must be fetched fresh for each API call
 
 ### File Requirements
 
@@ -125,6 +129,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-workspace-bounds" \
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -139,6 +144,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-workspace-bounds" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -163,6 +169,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -178,6 +185,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-svg-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -201,6 +209,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `transform_params` (str): A JSON string with transformation parameters (`[sx, shy, shx, sy, tx, ty]`) which operates in mm space.
     - `sx`: Scale factor in the x-direction
     - `shy`: Shear factor in the y-direction
@@ -217,7 +226,14 @@ curl -X POST "https://beta.fslaser.com/api/jobs/project3d-svg-lap" \
 #### Example CURL (standard-png-lap)
 
 ```bash
-curl -X POST "https://beta.fslaser.com/api/jobs/standard-png-lap"   -F "pass_code=my-pass-code"   -F "device_id=AE356O3E89D"   -F "png_file=@path/to/your/image.png"   -F "json_file=@path/to/your/color_settings.json"   -F "transform_params=[0.1, 0, 0, 0.1, 20.0, 15.25]"   --output generated_file.lap
+curl -X POST "https://beta.fslaser.com/api/jobs/standard-png-lap" \
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "png_file=@path/to/your/image.png" \
+  -F "json_file=@path/to/your/color_settings.json" \
+  -F "transform_params=[0.1, 0, 0, 0.1, 20.0, 15.25]" \
+  --output generated_file.lap
 ```
 
 **NOTE**:
@@ -313,6 +329,7 @@ The API assumes all input images are at 96 DPI (dots per inch) when converting t
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `color` (str): Stroke color for the vector paths.
 - **Files**:
   - `npz_file`: The NPZ file containing vector paths.
@@ -321,7 +338,14 @@ The API assumes all input images are at 96 DPI (dots per inch) when converting t
 #### Example CURL (standard-npz-paths2d-lap)
 
 ```bash
-curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "pass_code=my-pass-code"   -F "device_id=AE356O3E89D"   -F "npz_file=@path/to/your/file.npz"   -F "json_file=@path/to/your/color_settings.json"   -F "color=#FF5733"   --output generated_file.lap
+curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap" \
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "npz_file=@path/to/your/file.npz" \
+  -F "json_file=@path/to/your/color_settings.json" \
+  -F "color=#FF5733" \
+  --output generated_file.lap
 ```
 
 ### Process Points (NPZ)
@@ -337,6 +361,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
 - **Files**:
   - `npz_file`: The NPZ file containing vector paths.
   - `json_file`: A JSON file containing color settings.
@@ -344,7 +369,13 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-paths2d-lap"   -F "
 #### Example CURL (standard-npz-points2d-lap)
 
 ```bash
-curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F "pass_code=my-pass-code"   -F "device_id=AE356O3E89D"   -F "npz_file=@path/to/your/file.npz"   -F "json_file=@path/to/your/color_settings.json"   --output generated_file.lap
+curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap" \
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "npz_file=@path/to/your/file.npz" \
+  -F "json_file=@path/to/your/color_settings.json" \
+  --output generated_file.lap
 ```
 
 ### Process GVDesign Job
@@ -360,6 +391,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F 
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -374,6 +406,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-npz-points2d-lap"   -F 
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -396,6 +429,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `workspaceX_mm_min` (float, optional): Workspace X min in millimeters to position the file in the workspace correctly.
   - `workspaceX_mm_max` (float, optional): Workspace X max in millimeters to position the file in the workspace correctly.
   - `workspaceY_mm_min` (float, optional): Workspace Y min in millimeters to position the file in the workspace correctly.
@@ -410,6 +444,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-gvdesign-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "workspaceX_mm_min=-50.0" \
   -F "workspaceX_mm_max=50.0" \
   -F "workspaceY_mm_min=-50.0" \
@@ -436,6 +471,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
 - **Form Fields**:
   - `pass_code` (str): User pass code for authentication obtained from the API website under username.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
 - **Files**:
   - `lap_file`: The `.lap` file to execute.
 
@@ -445,6 +481,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/standard-pdf-lap" \
 curl -X POST "https://beta.fslaser.com/api/jobs/api-run-lap-job" \
   -F "pass_code=my-pass-code" \
   -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "lap_file=@path/to/your/job.lap"
 ```
 
@@ -461,13 +498,15 @@ curl -X POST "https://beta.fslaser.com/api/jobs/api-run-lap-job" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
 
 #### Example CURL (api-stop-job)
 
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/api-stop-job" \
   -F "pass_code=my-pass-code" \
-  -F "device_id=AE356O3E89D"
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
 ```
 
 ### Query Job Status
@@ -483,13 +522,15 @@ curl -X POST "https://beta.fslaser.com/api/jobs/api-stop-job" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
 
 #### Example CURL (api-query-job-status)
 
 ```bash
 curl -X POST "https://beta.fslaser.com/api/jobs/api-query-job-status" \
   -F "pass_code=my-pass-code" \
-  -F "device_id=AE356O3E89D"
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
 ```
 
 ### Capture Image
@@ -506,6 +547,7 @@ The request should be `multipart/form-data` and include the following fields:
 
 - `device_id` (string, required): The id (MAC address) for the device.
 - `pass_code` (string, required): The user's pass code.
+- `device_auth_code` (string, required): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
 - `is_corrected` (boolean, optional): Specifies whether the captured image should be corrected. If `true`, the corrected image is returned. Otherwise, the original image is returned. Defaults to `false` if not specified.
 
 **Responses:**
@@ -539,6 +581,7 @@ The request should be `multipart/form-data` and include the following fields:
 curl -X POST "YOUR_SERVER_URL/api/jobs/capture-image" \
      -F "pass_code=your_pass_code" \
      -F "device_id=your_device_id" \
+     -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
      -F "is_corrected=true" \
      --output captured_image.jpg
 ```
@@ -558,6 +601,7 @@ curl -X POST "YOUR_SERVER_URL/api/jobs/capture-image" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `x_mm` (float, optional): X position in millimeters. Can be `null` to skip moving along X.
   - `y_mm` (float, optional): Y position in millimeters. Can be `null` to skip moving along Y.
   - `z_mm` (float, optional): Z position in millimeters. Can be `null` to skip moving along Z.
@@ -570,10 +614,12 @@ This endpoint allows you to move the gantry of a device to a specific position. 
 
 ```sh
 curl -X POST "https://your-server/api/jobs/gantry-move" \
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "x_mm=100.0" \
   -F "y_mm=50.0" \
   -F "z_mm=" \
-  -F "device_id=AE356O3E89D"
 ```
 
 ### Success Response
@@ -615,14 +661,17 @@ curl -X POST "https://your-server/api/jobs/gantry-move" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `gpio_pin` (int): The pin to set.
 
 #### Example cURL (set-gpio)
 
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
-  -F "gpio_pin=1" \
-  -F "device_id=AE356O3E89D"
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "gpio_pin=1"
 ```
 
 **Success Response**:
@@ -645,14 +694,17 @@ curl -X POST "https://beta.fslaser.com/api/jobs/set-gpio" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `gpio_pin` (int): The pin to clear.
 
 #### Example CURL (clear-gpio)
 
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
-  -F "gpio_pin=1" \
-  -F "device_id=AE356O3E89D"
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "gpio_pin=1"
 ```
 
 **Success Response**:
@@ -675,14 +727,17 @@ curl -X POST "https://beta.fslaser.com/api/jobs/clear-gpio" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `gpio_pin` (int): The pin to get.
 
 #### Example CURL (get-gpio)
 
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
-  -F "gpio_pin=1" \
-  -F "device_id=AE356O3E89D"
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "gpio_pin=1"
 ```
 
 **Success Response**:
@@ -712,6 +767,7 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `gpio_pin` (int): The pin to set.
   - `blink_duration_ms` (int, optional): The duration of the blink in milliseconds. Default is 1000, if not specified.
 
@@ -719,9 +775,11 @@ curl -X POST "https://beta.fslaser.com/api/jobs/get-gpio" \
 
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
   -F "gpio_pin=1" \
-  -F "blink_duration_ms=250" \
-  -F "device_id=AE356O3E89D"
+  -F "blink_duration_ms=250"
 ```
 
 **Success Response**:
@@ -744,14 +802,17 @@ curl -X POST "https://beta.fslaser.com/api/jobs/blink-gpio" \
 - **Form Fields**:
   - `pass_code` (str): The user's pass code obtained from RE4.
   - `device_id` (str): Device ID for authentication.
+  - `device_auth_code` (str): Device authentication code obtained from `http://{device_ip}/2fa` endpoint.
   - `gpio_command` (str): The command to send.
 
 #### Example cURL (send-gpio)
 
 ```sh
 curl -X POST "https://beta.fslaser.com/api/jobs/send-gpio" \
-  -F "gpio_command=set pin1" \
-  -F "device_id=AE356O3E89D"
+  -F "pass_code=my-pass-code" \
+  -F "device_id=AE356O3E89D" \
+  -F "device_auth_code=$(curl -s http://192.168.1.100/2fa | jq -r '.totp')" \
+  -F "gpio_command=set pin1"
 ```
 
 **Success Response**:

--- a/api_capture_image.py
+++ b/api_capture_image.py
@@ -5,6 +5,7 @@ import shutil
 BASE_URL = "https://beta.fslaser.com/api/jobs"  # Replace with your actual server URL
 DEVICE_ID = "AE356O3E89D"  # Replace with a valid device ID
 PASS_CODE = "Pork_Hacking_98"  # Replace with a valid pass code
+DEVICE_IP = "192.168.1.100"  # Replace with a valid device IP address
 # --- End Configuration ---
 
 def test_capture_image(is_corrected_value=None, output_filename="captured_image.jpg"):
@@ -17,9 +18,12 @@ def test_capture_image(is_corrected_value=None, output_filename="captured_image.
     """
     endpoint = f"{BASE_URL}/capture-image"
     
+    # get the device auth code from the {device_ip}/2fa
+    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
+        "device_auth_code": device_auth_code,
     }
 
     if is_corrected_value is not None:

--- a/api_capture_image.py
+++ b/api_capture_image.py
@@ -3,7 +3,7 @@ import shutil
 
 # --- Configuration ---
 BASE_URL = "https://beta.fslaser.com/api/jobs"  # Replace with your actual server URL
-DEVICE_ACCESS_CODE = "Chastity:Lasso:87"  # Replace with a valid device access code
+DEVICE_ID = "AE356O3E89D"  # Replace with a valid device ID
 PASS_CODE = "Pork_Hacking_98"  # Replace with a valid pass code
 # --- End Configuration ---
 
@@ -18,7 +18,7 @@ def test_capture_image(is_corrected_value=None, output_filename="captured_image.
     endpoint = f"{BASE_URL}/capture-image"
     
     form_data = {
-        "device_access_code": DEVICE_ACCESS_CODE,
+        "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
     }
 

--- a/api_capture_image.py
+++ b/api_capture_image.py
@@ -19,7 +19,11 @@ def test_capture_image(is_corrected_value=None, output_filename="captured_image.
     endpoint = f"{BASE_URL}/capture-image"
     
     # get the device auth code from the {device_ip}/2fa
-    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
+    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
+    if not totp_response.get("success"):
+        raise Exception(f"Failed to get TOTP: {totp_response}")
+    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,

--- a/api_gantry_move.py
+++ b/api_gantry_move.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_gantry_move(server, pass_code, device_access_code, x_mm=None, y_mm=None, z_mm=None):
+def test_gantry_move(server, pass_code, device_id, x_mm=None, y_mm=None, z_mm=None):
     """
     Test the gantry-move endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         x_mm (float, optional): X position in millimeters. Default is None (do not move X).
         y_mm (float, optional): Y position in millimeters. Default is None (do not move Y).
         z_mm (float, optional): Z position in millimeters. Default is None (do not move Z).
@@ -18,7 +18,7 @@ def test_gantry_move(server, pass_code, device_access_code, x_mm=None, y_mm=None
         # Prepare the data for the POST request
         data = {
             "pass_code": pass_code,
-            "device_access_code": device_access_code,
+            "device_id": device_id,
         }
         if x_mm is not None:
             data["x_mm"] = str(x_mm)
@@ -43,20 +43,20 @@ def test_gantry_move(server, pass_code, device_access_code, x_mm=None, y_mm=None
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
 
     # Example test cases
     print("\n--- Move X only ---")
-    test_gantry_move(server, pass_code, device_access_code, x_mm=100.0)
+    test_gantry_move(server, pass_code, device_id, x_mm=100.0)
 
     print("\n--- Move Y only ---")
-    test_gantry_move(server, pass_code, device_access_code, y_mm=50.0)
+    test_gantry_move(server, pass_code, device_id, y_mm=50.0)
 
     print("\n--- Move X and Y ---")
-    test_gantry_move(server, pass_code, device_access_code, x_mm=100.0, y_mm=50.0)
+    test_gantry_move(server, pass_code, device_id, x_mm=100.0, y_mm=50.0)
 
     print("\n--- Move all axes ---")
-    test_gantry_move(server, pass_code, device_access_code, x_mm=100.0, y_mm=50.0, z_mm=10.0)
+    test_gantry_move(server, pass_code, device_id, x_mm=100.0, y_mm=50.0, z_mm=10.0)
 
     print("\n--- No axes (should fail) ---")
-    test_gantry_move(server, pass_code, device_access_code)
+    test_gantry_move(server, pass_code, device_id)

--- a/api_gantry_move.py
+++ b/api_gantry_move.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_gantry_move(server, pass_code, device_id, device_ip, x_mm=None, y_mm=None, z_mm=None):
+def test_gantry_move(server, pass_code, device_id, x_mm=None, y_mm=None, z_mm=None, auth_code=None):
     """
     Test the gantry-move endpoint.
 
@@ -8,7 +8,7 @@ def test_gantry_move(server, pass_code, device_id, device_ip, x_mm=None, y_mm=No
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
         x_mm (float, optional): X position in millimeters. Default is None (do not move X).
         y_mm (float, optional): Y position in millimeters. Default is None (do not move Y).
         z_mm (float, optional): Z position in millimeters. Default is None (do not move Z).
@@ -16,18 +16,15 @@ def test_gantry_move(server, pass_code, device_id, device_ip, x_mm=None, y_mm=No
     try:
         url = server + "/api/jobs/gantry-move"
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
-            "device_auth_code": device_auth_code,
         }
+        
+        # Only include auth_code if provided
+        if auth_code:
+            data["device_auth_code"] = auth_code
         if x_mm is not None:
             data["x_mm"] = str(x_mm)
         if y_mm is not None:
@@ -52,19 +49,30 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
-    # Example test cases
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
     print("\n--- Move X only ---")
-    test_gantry_move(server, pass_code, device_id, device_ip, x_mm=100.0)
+    test_gantry_move(server, pass_code, device_id, x_mm=100.0)
 
     print("\n--- Move Y only ---")
-    test_gantry_move(server, pass_code, device_id, device_ip, y_mm=50.0)
+    test_gantry_move(server, pass_code, device_id, y_mm=50.0)
 
     print("\n--- Move X and Y ---")
-    test_gantry_move(server, pass_code, device_id, device_ip, x_mm=100.0, y_mm=50.0)
+    test_gantry_move(server, pass_code, device_id, x_mm=100.0, y_mm=50.0)
 
     print("\n--- Move all axes ---")
-    test_gantry_move(server, pass_code, device_id, device_ip, x_mm=100.0, y_mm=50.0, z_mm=10.0)
+    test_gantry_move(server, pass_code, device_id, x_mm=100.0, y_mm=50.0, z_mm=10.0)
 
     print("\n--- No axes (should fail) ---")
-    test_gantry_move(server, pass_code, device_id, device_ip)
+    test_gantry_move(server, pass_code, device_id)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     print("\n--- Move X only (with TOTP) ---")
+    #     test_gantry_move(server, pass_code, device_id, x_mm=100.0, auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/api_gantry_move.py
+++ b/api_gantry_move.py
@@ -17,7 +17,11 @@ def test_gantry_move(server, pass_code, device_id, device_ip, x_mm=None, y_mm=No
         url = server + "/api/jobs/gantry-move"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data for the POST request
         data = {
             "pass_code": pass_code,

--- a/api_gantry_move.py
+++ b/api_gantry_move.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_gantry_move(server, pass_code, device_id, x_mm=None, y_mm=None, z_mm=None):
+def test_gantry_move(server, pass_code, device_id, device_ip, x_mm=None, y_mm=None, z_mm=None):
     """
     Test the gantry-move endpoint.
 
@@ -8,6 +8,7 @@ def test_gantry_move(server, pass_code, device_id, x_mm=None, y_mm=None, z_mm=No
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         x_mm (float, optional): X position in millimeters. Default is None (do not move X).
         y_mm (float, optional): Y position in millimeters. Default is None (do not move Y).
         z_mm (float, optional): Z position in millimeters. Default is None (do not move Z).
@@ -15,10 +16,13 @@ def test_gantry_move(server, pass_code, device_id, x_mm=None, y_mm=None, z_mm=No
     try:
         url = server + "/api/jobs/gantry-move"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Prepare the data for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
+            "device_auth_code": device_auth_code,
         }
         if x_mm is not None:
             data["x_mm"] = str(x_mm)
@@ -44,19 +48,19 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     # Example test cases
     print("\n--- Move X only ---")
-    test_gantry_move(server, pass_code, device_id, x_mm=100.0)
+    test_gantry_move(server, pass_code, device_id, device_ip, x_mm=100.0)
 
     print("\n--- Move Y only ---")
-    test_gantry_move(server, pass_code, device_id, y_mm=50.0)
+    test_gantry_move(server, pass_code, device_id, device_ip, y_mm=50.0)
 
     print("\n--- Move X and Y ---")
-    test_gantry_move(server, pass_code, device_id, x_mm=100.0, y_mm=50.0)
+    test_gantry_move(server, pass_code, device_id, device_ip, x_mm=100.0, y_mm=50.0)
 
     print("\n--- Move all axes ---")
-    test_gantry_move(server, pass_code, device_id, x_mm=100.0, y_mm=50.0, z_mm=10.0)
+    test_gantry_move(server, pass_code, device_id, device_ip, x_mm=100.0, y_mm=50.0, z_mm=10.0)
 
     print("\n--- No axes (should fail) ---")
-    test_gantry_move(server, pass_code, device_id)
+    test_gantry_move(server, pass_code, device_id, device_ip)

--- a/api_gpio.py
+++ b/api_gpio.py
@@ -17,7 +17,11 @@ def test_set_gpio(gpio_pin: int):
     endpoint = f"{BASE_URL}/set-gpio"
     
     # get the device auth code from the {device_ip}/2fa
-    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
+    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
+    if not totp_response.get("success"):
+        raise Exception(f"Failed to get TOTP: {totp_response}")
+    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
@@ -65,7 +69,11 @@ def test_clear_gpio(gpio_pin: int):
     endpoint = f"{BASE_URL}/clear-gpio"
     
     # get the device auth code from the {device_ip}/2fa
-    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
+    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
+    if not totp_response.get("success"):
+        raise Exception(f"Failed to get TOTP: {totp_response}")
+    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
@@ -113,7 +121,11 @@ def test_get_gpio(gpio_pin: int):
     endpoint = f"{BASE_URL}/get-gpio"
     
     # get the device auth code from the {device_ip}/2fa
-    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
+    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
+    if not totp_response.get("success"):
+        raise Exception(f"Failed to get TOTP: {totp_response}")
+    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
@@ -169,7 +181,11 @@ def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None):
     endpoint = f"{BASE_URL}/blink-gpio"
     
     # get the device auth code from the {device_ip}/2fa
-    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
+    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
+    if not totp_response.get("success"):
+        raise Exception(f"Failed to get TOTP: {totp_response}")
+    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
@@ -221,7 +237,11 @@ def test_send_gpio(gpio_command: str):
     endpoint = f"{BASE_URL}/send-gpio"
     
     # get the device auth code from the {device_ip}/2fa
-    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
+    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
+    if not totp_response.get("success"):
+        raise Exception(f"Failed to get TOTP: {totp_response}")
+    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,

--- a/api_gpio.py
+++ b/api_gpio.py
@@ -2,7 +2,7 @@ import requests
 
 # --- Configuration ---
 BASE_URL = "https://beta.fslaser.com/api/jobs"  # Replace with your actual server URL
-DEVICE_ACCESS_CODE = "Chastity:Lasso:87"  # Replace with a valid device access code
+DEVICE_ID = "AE356O3E89D"  # Replace with a valid device ID
 PASS_CODE = "Pork_Hacking_98"  # Replace with a valid pass code
 # --- End Configuration ---
 
@@ -16,7 +16,7 @@ def test_set_gpio(gpio_pin: int):
     endpoint = f"{BASE_URL}/set-gpio"
     
     form_data = {
-        "device_access_code": DEVICE_ACCESS_CODE,
+        "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
     }
 
@@ -61,7 +61,7 @@ def test_clear_gpio(gpio_pin: int):
     endpoint = f"{BASE_URL}/clear-gpio"
     
     form_data = {
-        "device_access_code": DEVICE_ACCESS_CODE,
+        "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
     }
 
@@ -106,7 +106,7 @@ def test_get_gpio(gpio_pin: int):
     endpoint = f"{BASE_URL}/set-gpio"
     
     form_data = {
-        "device_access_code": DEVICE_ACCESS_CODE,
+        "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
     }
 
@@ -159,7 +159,7 @@ def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None):
     endpoint = f"{BASE_URL}/blink-gpio"
     
     form_data = {
-        "device_access_code": DEVICE_ACCESS_CODE,
+        "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
     }
 
@@ -208,7 +208,7 @@ def test_send_gpio(gpio_command: str):
     endpoint = f"{BASE_URL}/send-gpio"
     
     form_data = {
-        "device_access_code": DEVICE_ACCESS_CODE,
+        "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
     }
 

--- a/api_gpio.py
+++ b/api_gpio.py
@@ -4,10 +4,9 @@ import requests
 BASE_URL = "https://beta.fslaser.com/api/jobs"  # Replace with your actual server URL
 DEVICE_ID = "AE356O3E89D"  # Replace with a valid device ID
 PASS_CODE = "Pork_Hacking_98"  # Replace with a valid pass code
-DEVICE_IP = "192.168.1.100"  # Replace with a valid device IP address
 # --- End Configuration ---
 
-def test_set_gpio(gpio_pin: int):
+def test_set_gpio(gpio_pin: int, auth_code=None):
     """
     Tests the /api/jobs/set-gpio endpoint.
 
@@ -16,17 +15,14 @@ def test_set_gpio(gpio_pin: int):
     """
     endpoint = f"{BASE_URL}/set-gpio"
     
-    # get the device auth code from the {device_ip}/2fa
-    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
-    if not totp_response.get("success"):
-        raise Exception(f"Failed to get TOTP: {totp_response}")
-    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
-        "device_auth_code": device_auth_code,
     }
+    
+    # Only include auth_code if provided
+    if auth_code:
+        form_data["device_auth_code"] = auth_code
 
     if gpio_pin is not None:
         form_data["gpio_pin"] = int(gpio_pin) # FastAPI expects an integer for the GPIO pin
@@ -59,7 +55,7 @@ def test_set_gpio(gpio_pin: int):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
-def test_clear_gpio(gpio_pin: int):
+def test_clear_gpio(gpio_pin: int, auth_code=None):
     """
     Tests the /api/jobs/clear-gpio endpoint.
 
@@ -68,17 +64,14 @@ def test_clear_gpio(gpio_pin: int):
     """
     endpoint = f"{BASE_URL}/clear-gpio"
     
-    # get the device auth code from the {device_ip}/2fa
-    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
-    if not totp_response.get("success"):
-        raise Exception(f"Failed to get TOTP: {totp_response}")
-    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
-        "device_auth_code": device_auth_code,
     }
+    
+    # Only include auth_code if provided
+    if auth_code:
+        form_data["device_auth_code"] = auth_code
 
     if gpio_pin is not None:
         form_data["gpio_pin"] = int(gpio_pin) # FastAPI expects an integer for the GPIO pin
@@ -111,7 +104,7 @@ def test_clear_gpio(gpio_pin: int):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
-def test_get_gpio(gpio_pin: int):
+def test_get_gpio(gpio_pin: int, auth_code=None):
     """
     Test the /api/jobs/get-gpio endpoint.
 
@@ -120,17 +113,14 @@ def test_get_gpio(gpio_pin: int):
     """
     endpoint = f"{BASE_URL}/get-gpio"
     
-    # get the device auth code from the {device_ip}/2fa
-    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
-    if not totp_response.get("success"):
-        raise Exception(f"Failed to get TOTP: {totp_response}")
-    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
-        "device_auth_code": device_auth_code,
     }
+    
+    # Only include auth_code if provided
+    if auth_code:
+        form_data["device_auth_code"] = auth_code
 
     if gpio_pin is not None:
         form_data["gpio_pin"] = int(gpio_pin) # FastAPI expects an integer for the GPIO pin
@@ -169,7 +159,7 @@ def test_get_gpio(gpio_pin: int):
     except Exception as e:
         print(f"An error occurred: {e}")
 
-def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None):
+def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None, auth_code=None):
     """
     Tests the /api/jobs/blink-gpio endpoint.
 
@@ -180,17 +170,14 @@ def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None):
     """
     endpoint = f"{BASE_URL}/blink-gpio"
     
-    # get the device auth code from the {device_ip}/2fa
-    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
-    if not totp_response.get("success"):
-        raise Exception(f"Failed to get TOTP: {totp_response}")
-    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
-        "device_auth_code": device_auth_code,
     }
+    
+    # Only include auth_code if provided
+    if auth_code:
+        form_data["device_auth_code"] = auth_code
 
     if gpio_pin is not None:
         form_data["gpio_pin"] = int(gpio_pin) # FastAPI expects an integer for the GPIO pin
@@ -227,7 +214,7 @@ def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None):
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
-def test_send_gpio(gpio_command: str):
+def test_send_gpio(gpio_command: str, auth_code=None):
     """
     Tests the /api/jobs/send-gpio endpoint.
 
@@ -236,17 +223,14 @@ def test_send_gpio(gpio_command: str):
     """
     endpoint = f"{BASE_URL}/send-gpio"
     
-    # get the device auth code from the {device_ip}/2fa
-    # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-    totp_response = requests.post(f"https://{DEVICE_IP}/2fa", verify=False).json()
-    if not totp_response.get("success"):
-        raise Exception(f"Failed to get TOTP: {totp_response}")
-    device_auth_code = totp_response["totp"]["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
-        "device_auth_code": device_auth_code,
     }
+    
+    # Only include auth_code if provided
+    if auth_code:
+        form_data["device_auth_code"] = auth_code
 
     if gpio_command is not None:
         form_data["gpio_command"] = gpio_command # FastAPI expects a string for the GPIO command
@@ -280,8 +264,10 @@ def test_send_gpio(gpio_command: str):
         print(f"An unexpected error occurred: {e}")
 
 if __name__ == "__main__":
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    
     # --- Test Cases ---
-
     # 1. Test with set_gpio with gpio_pin = 1
     test_set_gpio(gpio_pin=1)
 
@@ -317,6 +303,19 @@ if __name__ == "__main__":
 
     # 12. Test with send_gpio with gpio_command = "clear pin1"
     test_send_gpio(gpio_command="clear pin1")
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     print("Testing GPIO operations with TOTP...")
+    #     test_set_gpio(gpio_pin=1, auth_code=auth_code)
+    #     test_clear_gpio(gpio_pin=1, auth_code=auth_code)
+    #     test_get_gpio(gpio_pin=1, auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")
 
     print("\n--- All tests finished ---")
     

--- a/api_gpio.py
+++ b/api_gpio.py
@@ -4,6 +4,7 @@ import requests
 BASE_URL = "https://beta.fslaser.com/api/jobs"  # Replace with your actual server URL
 DEVICE_ID = "AE356O3E89D"  # Replace with a valid device ID
 PASS_CODE = "Pork_Hacking_98"  # Replace with a valid pass code
+DEVICE_IP = "192.168.1.100"  # Replace with a valid device IP address
 # --- End Configuration ---
 
 def test_set_gpio(gpio_pin: int):
@@ -15,9 +16,12 @@ def test_set_gpio(gpio_pin: int):
     """
     endpoint = f"{BASE_URL}/set-gpio"
     
+    # get the device auth code from the {device_ip}/2fa
+    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
+        "device_auth_code": device_auth_code,
     }
 
     if gpio_pin is not None:
@@ -60,9 +64,12 @@ def test_clear_gpio(gpio_pin: int):
     """
     endpoint = f"{BASE_URL}/clear-gpio"
     
+    # get the device auth code from the {device_ip}/2fa
+    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
+        "device_auth_code": device_auth_code,
     }
 
     if gpio_pin is not None:
@@ -103,11 +110,14 @@ def test_get_gpio(gpio_pin: int):
     Args:
         gpio_pin (int): The GPIO pin to get.
     """
-    endpoint = f"{BASE_URL}/set-gpio"
+    endpoint = f"{BASE_URL}/get-gpio"
     
+    # get the device auth code from the {device_ip}/2fa
+    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
+        "device_auth_code": device_auth_code,
     }
 
     if gpio_pin is not None:
@@ -158,9 +168,12 @@ def test_blink_gpio(gpio_pin: int, blink_duration_ms: int | None = None):
     """
     endpoint = f"{BASE_URL}/blink-gpio"
     
+    # get the device auth code from the {device_ip}/2fa
+    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
+        "device_auth_code": device_auth_code,
     }
 
     if gpio_pin is not None:
@@ -207,9 +220,12 @@ def test_send_gpio(gpio_command: str):
     """
     endpoint = f"{BASE_URL}/send-gpio"
     
+    # get the device auth code from the {device_ip}/2fa
+    device_auth_code = requests.get(f"http://{DEVICE_IP}/2fa").json()["totp"]
     form_data = {
         "device_id": DEVICE_ID,
         "pass_code": PASS_CODE,
+        "device_auth_code": device_auth_code,
     }
 
     if gpio_command is not None:

--- a/api_query_job_status.py
+++ b/api_query_job_status.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_query_job_status(server, pass_code, device_id):
+def test_query_job_status(server, pass_code, device_id, device_ip):
     """
     Test the api-query-job-status endpoint.
 
@@ -8,14 +8,18 @@ def test_query_job_status(server, pass_code, device_id):
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
     """
     try:
         url = server + "/api/jobs/api-query-job-status"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
+            "device_auth_code": device_auth_code,
         }
 
         # Send the POST request
@@ -36,5 +40,5 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-
-    test_query_job_status(server, pass_code, device_id)
+    device_ip = "192.168.1.100" #Device IP for device authentication.
+    test_query_job_status(server, pass_code, device_id, device_ip)

--- a/api_query_job_status.py
+++ b/api_query_job_status.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_query_job_status(server, pass_code, device_id, device_ip):
+def test_query_job_status(server, pass_code, device_id, auth_code=None):
     """
     Test the api-query-job-status endpoint.
 
@@ -8,23 +8,20 @@ def test_query_job_status(server, pass_code, device_id, device_ip):
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
     """
     try:
         url = server + "/api/jobs/api-query-job-status"
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
-            "device_auth_code": device_auth_code,
         }
+        
+        # Only include auth_code if provided
+        if auth_code:
+            data["device_auth_code"] = auth_code
 
         # Send the POST request
         print(f"Sending request to {url}...")
@@ -44,5 +41,16 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
-    test_query_job_status(server, pass_code, device_id, device_ip)
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    test_query_job_status(server, pass_code, device_id)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_query_job_status(server, pass_code, device_id, auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/api_query_job_status.py
+++ b/api_query_job_status.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_query_job_status(server, pass_code, device_access_code):
+def test_query_job_status(server, pass_code, device_id):
     """
     Test the api-query-job-status endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
     """
     try:
         url = server + "/api/jobs/api-query-job-status"
@@ -15,7 +15,7 @@ def test_query_job_status(server, pass_code, device_access_code):
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
-            "device_access_code": device_access_code,
+            "device_id": device_id,
         }
 
         # Send the POST request
@@ -35,6 +35,6 @@ def test_query_job_status(server, pass_code, device_access_code):
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
 
-    test_query_job_status(server, pass_code, device_access_code)
+    test_query_job_status(server, pass_code, device_id)

--- a/api_query_job_status.py
+++ b/api_query_job_status.py
@@ -14,7 +14,11 @@ def test_query_job_status(server, pass_code, device_id, device_ip):
         url = server + "/api/jobs/api-query-job-status"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,

--- a/api_run_lap_job.py
+++ b/api_run_lap_job.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_run_lap_job(server, pass_code, device_id, device_ip, lap_file_path, soft_limit_check):
+def test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check, auth_code=None):
     """
     Test the api-run-lap-job endpoint.
 
@@ -8,24 +8,21 @@ def test_run_lap_job(server, pass_code, device_id, device_ip, lap_file_path, sof
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
     """
     try:
         url = server + "/api/jobs/api-run-lap-job"
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
             "soft_limit_check": soft_limit_check,
-            "device_auth_code": device_auth_code,
         }
+        
+        # Only include auth_code if provided
+        if auth_code:
+            data["device_auth_code"] = auth_code
         
         # Open and prepare the LAP file
         files = {
@@ -50,7 +47,19 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
     lap_file_path = "C:/Users/Administrator/Desktop/test.lap" #Path to the LAP file to be uploaded
     soft_limit_check = True
-    test_run_lap_job(server, pass_code, device_id, device_ip, lap_file_path, soft_limit_check)
+    
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check, auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/api_run_lap_job.py
+++ b/api_run_lap_job.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check):
+def test_run_lap_job(server, pass_code, device_id, device_ip, lap_file_path, soft_limit_check):
     """
     Test the api-run-lap-job endpoint.
 
@@ -8,15 +8,19 @@ def test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_che
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
     """
     try:
         url = server + "/api/jobs/api-run-lap-job"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
             "soft_limit_check": soft_limit_check,
+            "device_auth_code": device_auth_code,
         }
         
         # Open and prepare the LAP file
@@ -42,6 +46,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     lap_file_path = "C:/Users/Administrator/Desktop/test.lap" #Path to the LAP file to be uploaded
     soft_limit_check = True
-    test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check)
+    test_run_lap_job(server, pass_code, device_id, device_ip, lap_file_path, soft_limit_check)

--- a/api_run_lap_job.py
+++ b/api_run_lap_job.py
@@ -14,7 +14,11 @@ def test_run_lap_job(server, pass_code, device_id, device_ip, lap_file_path, sof
         url = server + "/api/jobs/api-run-lap-job"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,

--- a/api_run_lap_job.py
+++ b/api_run_lap_job.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_run_lap_job(server, pass_code, device_access_code, lap_file_path, soft_limit_check):
+def test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check):
     """
     Test the api-run-lap-job endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
     """
     try:
         url = server + "/api/jobs/api-run-lap-job"
@@ -15,7 +15,7 @@ def test_run_lap_job(server, pass_code, device_access_code, lap_file_path, soft_
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
-            "device_access_code": device_access_code,
+            "device_id": device_id,
             "soft_limit_check": soft_limit_check,
         }
         
@@ -41,7 +41,7 @@ def test_run_lap_job(server, pass_code, device_access_code, lap_file_path, soft_
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     lap_file_path = "C:/Users/Administrator/Desktop/test.lap" #Path to the LAP file to be uploaded
     soft_limit_check = True
-    test_run_lap_job(server, pass_code, device_access_code, lap_file_path, soft_limit_check)
+    test_run_lap_job(server, pass_code, device_id, lap_file_path, soft_limit_check)

--- a/api_stop_job.py
+++ b/api_stop_job.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_stop_job(server, pass_code, device_access_code):
+def test_stop_job(server, pass_code, device_id):
     """
     Test the api-stop-job endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
     """
     try:
         url = server + "/api/jobs/api-stop-job"
@@ -15,7 +15,7 @@ def test_stop_job(server, pass_code, device_access_code):
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
-            "device_access_code": device_access_code,
+            "device_id": device_id,
         }
 
         # Send the POST request
@@ -35,6 +35,6 @@ def test_stop_job(server, pass_code, device_access_code):
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
 
-    test_stop_job(server, pass_code, device_access_code)
+    test_stop_job(server, pass_code, device_id)

--- a/api_stop_job.py
+++ b/api_stop_job.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_stop_job(server, pass_code, device_id, device_ip):
+def test_stop_job(server, pass_code, device_id, auth_code=None):
     """
     Test the api-stop-job endpoint.
 
@@ -8,23 +8,20 @@ def test_stop_job(server, pass_code, device_id, device_ip):
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
     """
     try:
         url = server + "/api/jobs/api-stop-job"
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
-            "device_auth_code": device_auth_code,
         }
+        
+        # Only include auth_code if provided
+        if auth_code:
+            data["device_auth_code"] = auth_code
 
         # Send the POST request
         print(f"Sending request to {url}...")
@@ -44,5 +41,16 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
-    test_stop_job(server, pass_code, device_id, device_ip)
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    test_stop_job(server, pass_code, device_id)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_stop_job(server, pass_code, device_id, auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/api_stop_job.py
+++ b/api_stop_job.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_stop_job(server, pass_code, device_id):
+def test_stop_job(server, pass_code, device_id, device_ip):
     """
     Test the api-stop-job endpoint.
 
@@ -8,14 +8,18 @@ def test_stop_job(server, pass_code, device_id):
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
     """
     try:
         url = server + "/api/jobs/api-stop-job"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,
             "device_id": device_id,
+            "device_auth_code": device_auth_code,
         }
 
         # Send the POST request
@@ -36,5 +40,5 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-
-    test_stop_job(server, pass_code, device_id)
+    device_ip = "192.168.1.100" #Device IP for device authentication.
+    test_stop_job(server, pass_code, device_id, device_ip)

--- a/api_stop_job.py
+++ b/api_stop_job.py
@@ -14,7 +14,11 @@ def test_stop_job(server, pass_code, device_id, device_ip):
         url = server + "/api/jobs/api-stop-job"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Prepare the data and files for the POST request
         data = {
             "pass_code": pass_code,

--- a/auth_code_grabber.py
+++ b/auth_code_grabber.py
@@ -1,0 +1,29 @@
+import requests
+
+def get_device_auth_code(device_ip):
+    """
+    Get device authentication code from the device's /2fa endpoint.
+    
+    Args:
+        device_ip (str): The IP address of the device.
+        
+    Returns:
+        str: The TOTP authentication code.
+        
+    Raises:
+        Exception: If failed to get TOTP or device is unreachable.
+    """
+    try:
+        # Try HTTPS first, then fallback to HTTP
+        try:
+            totp_response = requests.post(f"https://{device_ip}/2fa", verify=False, timeout=10).json()
+        except:
+            totp_response = requests.post(f"http://{device_ip}/2fa", timeout=10).json()
+            
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+            
+        return totp_response["totp"]["totp"]
+        
+    except Exception as e:
+        raise Exception(f"Could not get device auth code from {device_ip}: {e}")

--- a/get_workspace_size.py
+++ b/get_workspace_size.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_get_workspace_bounds(server, device_access_code):
+def test_get_workspace_bounds(server, device_id):
     """
     Test the standard-svg-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
     """
     try:
         url = server + "/api/jobs/get-workspace-bounds"
@@ -15,7 +15,7 @@ def test_get_workspace_bounds(server, device_access_code):
         # Open the files to upload
         # Prepare the data and files for the POST request
         data = {
-            "device_access_code": device_access_code,
+            "device_id": device_id,
         }
         # Send the POST request
         print(f"Sending request to {url}...")
@@ -29,5 +29,5 @@ def test_get_workspace_bounds(server, device_access_code):
 
 if __name__ == "__main__":
     server = "http://localhost:5005"  # Replace with your server URL
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
-    test_get_workspace_bounds(server, device_access_code)
+    device_id = "AE356O3E89D" #Device ID for device authentication.
+    test_get_workspace_bounds(server, device_id)

--- a/project3d_png.py
+++ b/project3d_png.py
@@ -19,7 +19,11 @@ def test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file
         url = f"{server}/api/jobs/project3d-png-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file, open(mesh_file_path, "rb") as mesh_file:
             # Prepare the data and files for the POST request

--- a/project3d_png.py
+++ b/project3d_png.py
@@ -1,7 +1,7 @@
 import requests
 import json
 
-def test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path):
+def test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path):
     """
     Test the standard-png-lap endpoint.
 
@@ -9,6 +9,7 @@ def test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -17,12 +18,15 @@ def test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json
     try:
         url = f"{server}/api/jobs/project3d-png-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file, open(mesh_file_path, "rb") as mesh_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
             files = {
@@ -53,10 +57,11 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     transform_params = [0.1, 0.0, 0.0, 0.1, 0, 0]  # Example transform parameters
     mesh_file_path = "sub.obj"
     output_file_path = "output_project3d_png.lap"
     # Run the test
-    test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path)
+    test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path)

--- a/project3d_png.py
+++ b/project3d_png.py
@@ -1,14 +1,14 @@
 import requests
 import json
 
-def test_get_project3d_png_lap(server, pass_code, device_access_code, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path):
+def test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path):
     """
     Test the standard-png-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -22,7 +22,7 @@ def test_get_project3d_png_lap(server, pass_code, device_access_code, png_file_p
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
             files = {
@@ -52,11 +52,11 @@ if __name__ == "__main__":
     # Define test parameters
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     transform_params = [0.1, 0.0, 0.0, 0.1, 0, 0]  # Example transform parameters
     mesh_file_path = "sub.obj"
     output_file_path = "output_project3d_png.lap"
     # Run the test
-    test_get_project3d_png_lap(server, pass_code, device_access_code, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path)
+    test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path)

--- a/project3d_png.py
+++ b/project3d_png.py
@@ -1,7 +1,7 @@
 import requests
 import json
 
-def test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path):
+def test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path, auth_code=None):
     """
     Test the standard-png-lap endpoint.
 
@@ -9,7 +9,7 @@ def test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -18,21 +18,18 @@ def test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file
     try:
         url = f"{server}/api/jobs/project3d-png-lap"
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file, open(mesh_file_path, "rb") as mesh_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
-                "device_auth_code": device_auth_code,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
+            
+            # Only include auth_code if provided
+            if auth_code:
+                data["device_auth_code"] = auth_code
             files = {
                 "png_file": png_file,
                 "json_file": json_file,
@@ -61,11 +58,21 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     transform_params = [0.1, 0.0, 0.0, 0.1, 0, 0]  # Example transform parameters
     mesh_file_path = "sub.obj"
     output_file_path = "output_project3d_png.lap"
-    # Run the test
-    test_get_project3d_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path)
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, output_file_path)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_get_project3d_png_lap(server, pass_code, device_id, png_file_path, json_file_path, mesh_file_path, transform_params, "output_project3d_png_with_totp.lap", auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/project3d_svg.py
+++ b/project3d_svg.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_get_project3d_svg_lap(server, pass_code, device_access_code, svg_file_path, json_file_path, mesh_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_project3d_svg_lap(server, pass_code, device_id, svg_file_path, json_file_path, mesh_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the standard-svg-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         svg_file_path (str): Path to the svg file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -20,7 +20,7 @@ def test_get_project3d_svg_lap(server, pass_code, device_access_code, svg_file_p
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -51,7 +51,7 @@ def test_get_project3d_svg_lap(server, pass_code, device_access_code, svg_file_p
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     svg_file_path = "test3.svg"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     mesh_file_path = "sub.obj"
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     workspaceY_mm_min = -50
     workspaceY_mm_max = 50
     test_get_project3d_svg_lap(
-        server, pass_code, device_access_code, svg_file_path, 
+        server, pass_code, device_id, svg_file_path, 
         json_file_path, mesh_file_path, output_file_path, 
         workspaceX_mm_min=workspaceX_mm_min, 
         workspaceX_mm_max=workspaceX_mm_max,

--- a/project3d_svg.py
+++ b/project3d_svg.py
@@ -17,7 +17,11 @@ def test_get_project3d_svg_lap(server, pass_code, device_id, device_ip, svg_file
         url = server + "/api/jobs/project3d-svg-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(svg_file_path, "rb") as svg_file, open(json_file_path, "rb") as json_file, open(mesh_file_path, "rb") as mesh_file:
             # Prepare the data and files for the POST request

--- a/project3d_svg.py
+++ b/project3d_svg.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_project3d_svg_lap(server, pass_code, device_id, device_ip, svg_file_path, json_file_path, mesh_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_project3d_svg_lap(server, pass_code, device_id, svg_file_path, json_file_path, mesh_file_path, output_file_path, auth_code=None, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the standard-svg-lap endpoint.
 
@@ -8,7 +8,7 @@ def test_get_project3d_svg_lap(server, pass_code, device_id, device_ip, svg_file
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
         svg_file_path (str): Path to the svg file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -16,24 +16,21 @@ def test_get_project3d_svg_lap(server, pass_code, device_id, device_ip, svg_file
     try:
         url = server + "/api/jobs/project3d-svg-lap"
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(svg_file_path, "rb") as svg_file, open(json_file_path, "rb") as json_file, open(mesh_file_path, "rb") as mesh_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
-                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
                 "workspaceY_mm_max": workspaceY_mm_max,
             }
+            
+            # Only include auth_code if provided
+            if auth_code:
+                data["device_auth_code"] = auth_code
             files = {
                 "svg_file": svg_file,
                 "json_file": json_file,
@@ -60,7 +57,6 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
     svg_file_path = "test3.svg"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     mesh_file_path = "sub.obj"
@@ -71,11 +67,31 @@ if __name__ == "__main__":
     workspaceX_mm_max = 50
     workspaceY_mm_min = -50
     workspaceY_mm_max = 50
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
     test_get_project3d_svg_lap(
-        server, pass_code, device_id, device_ip, svg_file_path, 
+        server, pass_code, device_id, svg_file_path, 
         json_file_path, mesh_file_path, output_file_path, 
         workspaceX_mm_min=workspaceX_mm_min, 
         workspaceX_mm_max=workspaceX_mm_max,
         workspaceY_mm_min=workspaceY_mm_min,
         workspaceY_mm_max=workspaceY_mm_max
     )
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_get_project3d_svg_lap(
+    #         server, pass_code, device_id, svg_file_path, 
+    #         json_file_path, mesh_file_path, "output_project3d_svg_with_totp.lap", 
+    #         auth_code=auth_code,
+    #         workspaceX_mm_min=workspaceX_mm_min, 
+    #         workspaceX_mm_max=workspaceX_mm_max,
+    #         workspaceY_mm_min=workspaceY_mm_min,
+    #         workspaceY_mm_max=workspaceY_mm_max
+    #     )
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/project3d_svg.py
+++ b/project3d_svg.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_project3d_svg_lap(server, pass_code, device_id, svg_file_path, json_file_path, mesh_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_project3d_svg_lap(server, pass_code, device_id, device_ip, svg_file_path, json_file_path, mesh_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the standard-svg-lap endpoint.
 
@@ -8,6 +8,7 @@ def test_get_project3d_svg_lap(server, pass_code, device_id, svg_file_path, json
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         svg_file_path (str): Path to the svg file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -15,12 +16,15 @@ def test_get_project3d_svg_lap(server, pass_code, device_id, svg_file_path, json
     try:
         url = server + "/api/jobs/project3d-svg-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(svg_file_path, "rb") as svg_file, open(json_file_path, "rb") as json_file, open(mesh_file_path, "rb") as mesh_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -52,6 +56,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     svg_file_path = "test3.svg"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     mesh_file_path = "sub.obj"
@@ -63,7 +68,7 @@ if __name__ == "__main__":
     workspaceY_mm_min = -50
     workspaceY_mm_max = 50
     test_get_project3d_svg_lap(
-        server, pass_code, device_id, svg_file_path, 
+        server, pass_code, device_id, device_ip, svg_file_path, 
         json_file_path, mesh_file_path, output_file_path, 
         workspaceX_mm_min=workspaceX_mm_min, 
         workspaceX_mm_max=workspaceX_mm_max,

--- a/standard_gvdesign.py
+++ b/standard_gvdesign.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_gvdesign_lap(server, pass_code, device_access_code, gvdesign_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_gvdesign_lap(server, pass_code, device_id, gvdesign_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the full-svg-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         gvdesign_file_path (str): Path to the gvdesign file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -20,7 +20,7 @@ def test_gvdesign_lap(server, pass_code, device_access_code, gvdesign_file_path,
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -50,7 +50,7 @@ def test_gvdesign_lap(server, pass_code, device_access_code, gvdesign_file_path,
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     gvdesign_file_path = "test2.gvdesign"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_gvdesign.lap"
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     test_gvdesign_lap(
         server=server,
         pass_code=pass_code,
-        device_access_code=device_access_code,
+        device_id=device_id,
         gvdesign_file_path=gvdesign_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,

--- a/standard_gvdesign.py
+++ b/standard_gvdesign.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_gvdesign_lap(server, pass_code, device_id, gvdesign_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_gvdesign_lap(server, pass_code, device_id, device_ip, gvdesign_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the full-svg-lap endpoint.
 
@@ -8,6 +8,7 @@ def test_gvdesign_lap(server, pass_code, device_id, gvdesign_file_path, json_fil
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         gvdesign_file_path (str): Path to the gvdesign file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -15,12 +16,15 @@ def test_gvdesign_lap(server, pass_code, device_id, gvdesign_file_path, json_fil
     try:
         url = server + "/api/jobs/standard-gvdesign-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(gvdesign_file_path, "rb") as gvdesign_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -51,6 +55,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     gvdesign_file_path = "test2.gvdesign"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_gvdesign.lap"
@@ -63,6 +68,7 @@ if __name__ == "__main__":
         server=server,
         pass_code=pass_code,
         device_id=device_id,
+        device_ip=device_ip,
         gvdesign_file_path=gvdesign_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,

--- a/standard_gvdesign.py
+++ b/standard_gvdesign.py
@@ -17,7 +17,11 @@ def test_gvdesign_lap(server, pass_code, device_id, device_ip, gvdesign_file_pat
         url = server + "/api/jobs/standard-gvdesign-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(gvdesign_file_path, "rb") as gvdesign_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request

--- a/standard_npz_paths2d.py
+++ b/standard_npz_paths2d.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_file_path, json_file_path, color, output_file_path):
+def test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, output_file_path, auth_code=None):
     """
     Test script for the '/api/jobs/standard-npz-paths2d-lap' endpoint.
 
@@ -8,7 +8,7 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_f
         server (str): Server URL.
         pass_code (str): User's pass code.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
         npz_file_path (str): Path to the input NPZ file.
         json_file_path (str): Path to the input JSON file.
         color (str): Stroke color for the vector.
@@ -17,12 +17,6 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_f
     try:
         url = f"{server}/api/jobs/standard-npz-paths2d-lap"  # Endpoint URL
 
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(npz_file_path, "rb") as npz_file, open(json_file_path, "rb") as json_file:
             # Prepare the request data
@@ -30,8 +24,11 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_f
                 "pass_code": pass_code,
                 "device_id": device_id,
                 "color": color,
-                "device_auth_code": device_auth_code,
             }
+            
+            # Only include auth_code if provided
+            if auth_code:
+                data["device_auth_code"] = auth_code
             files = {
                 "npz_file": npz_file,
                 "json_file": json_file,
@@ -106,12 +103,23 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
     npz_file_path = "test_paths.npz"  # Path to a sample NPZ file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     color = "#000000"  # Example color for the vector
     output_file_path = "output_npz_paths2d.lap"
 
     generate_star_vectors(file_path=npz_file_path)
-    # Run the test
-    test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_file_path, json_file_path, color, output_file_path)
+    
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, output_file_path)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, "output_npz_paths2d_with_totp.lap", auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/standard_npz_paths2d.py
+++ b/standard_npz_paths2d.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_get_standard_paths2d_lap(server, pass_code, device_access_code, npz_file_path, json_file_path, color, output_file_path):
+def test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, output_file_path):
     """
     Test script for the '/api/jobs/standard-npz-paths2d-lap' endpoint.
 
     Args:
         server (str): Server URL.
         pass_code (str): User's pass code.
-        device_access_code (str): Device access code.
+        device_id (str): Device ID for authentication.
         npz_file_path (str): Path to the input NPZ file.
         json_file_path (str): Path to the input JSON file.
         color (str): Stroke color for the vector.
@@ -21,7 +21,7 @@ def test_get_standard_paths2d_lap(server, pass_code, device_access_code, npz_fil
             # Prepare the request data
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "color": color,
             }
             files = {
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     # Define the server and input parameters
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     npz_file_path = "test_paths.npz"  # Path to a sample NPZ file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     color = "#000000"  # Example color for the vector
@@ -105,4 +105,4 @@ if __name__ == "__main__":
 
     generate_star_vectors(file_path=npz_file_path)
     # Run the test
-    test_get_standard_paths2d_lap(server, pass_code, device_access_code, npz_file_path, json_file_path, color, output_file_path)
+    test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, output_file_path)

--- a/standard_npz_paths2d.py
+++ b/standard_npz_paths2d.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, output_file_path):
+def test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_file_path, json_file_path, color, output_file_path):
     """
     Test script for the '/api/jobs/standard-npz-paths2d-lap' endpoint.
 
@@ -8,6 +8,7 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, j
         server (str): Server URL.
         pass_code (str): User's pass code.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         npz_file_path (str): Path to the input NPZ file.
         json_file_path (str): Path to the input JSON file.
         color (str): Stroke color for the vector.
@@ -16,6 +17,8 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, j
     try:
         url = f"{server}/api/jobs/standard-npz-paths2d-lap"  # Endpoint URL
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(npz_file_path, "rb") as npz_file, open(json_file_path, "rb") as json_file:
             # Prepare the request data
@@ -23,6 +26,7 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, j
                 "pass_code": pass_code,
                 "device_id": device_id,
                 "color": color,
+                "device_auth_code": device_auth_code,
             }
             files = {
                 "npz_file": npz_file,
@@ -98,6 +102,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     npz_file_path = "test_paths.npz"  # Path to a sample NPZ file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     color = "#000000"  # Example color for the vector
@@ -105,4 +110,4 @@ if __name__ == "__main__":
 
     generate_star_vectors(file_path=npz_file_path)
     # Run the test
-    test_get_standard_paths2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, color, output_file_path)
+    test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_file_path, json_file_path, color, output_file_path)

--- a/standard_npz_paths2d.py
+++ b/standard_npz_paths2d.py
@@ -18,7 +18,11 @@ def test_get_standard_paths2d_lap(server, pass_code, device_id, device_ip, npz_f
         url = f"{server}/api/jobs/standard-npz-paths2d-lap"  # Endpoint URL
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(npz_file_path, "rb") as npz_file, open(json_file_path, "rb") as json_file:
             # Prepare the request data

--- a/standard_npz_points2d.py
+++ b/standard_npz_points2d.py
@@ -17,7 +17,11 @@ def test_get_standard_points2d_lap(server, pass_code, device_id, device_ip, npz_
         url = f"{server}/api/jobs/standard-npz-points2d-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(npz_file_path, "rb") as npz_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request

--- a/standard_npz_points2d.py
+++ b/standard_npz_points2d.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_get_standard_points2d_lap(server, pass_code, device_access_code, npz_file_path, json_file_path, output_file_path):
+def test_get_standard_points2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, output_file_path):
     """
     Test the standard-npz-points2d-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         npz_file_path (str): Path to the .npz file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -20,7 +20,7 @@ def test_get_standard_points2d_lap(server, pass_code, device_access_code, npz_fi
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
             }
             files = {
                 "npz_file": npz_file,
@@ -81,7 +81,7 @@ if __name__ == "__main__":
     # Define test parameters
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     npz_file_path = "test_points.npz"  # Path to a sample .npz file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_npz_points2d.lap"  # Path to save the LAP file
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     generate_npz_from_png(png_file_path, npz_file_path)
 
     # Run the test
-    test_get_standard_points2d_lap(server, pass_code, device_access_code, npz_file_path, json_file_path, output_file_path)
+    test_get_standard_points2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, output_file_path)

--- a/standard_npz_points2d.py
+++ b/standard_npz_points2d.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_standard_points2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, output_file_path):
+def test_get_standard_points2d_lap(server, pass_code, device_id, device_ip, npz_file_path, json_file_path, output_file_path):
     """
     Test the standard-npz-points2d-lap endpoint.
 
@@ -8,6 +8,7 @@ def test_get_standard_points2d_lap(server, pass_code, device_id, npz_file_path, 
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         npz_file_path (str): Path to the .npz file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -15,12 +16,15 @@ def test_get_standard_points2d_lap(server, pass_code, device_id, npz_file_path, 
     try:
         url = f"{server}/api/jobs/standard-npz-points2d-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(npz_file_path, "rb") as npz_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
             }
             files = {
                 "npz_file": npz_file,
@@ -82,6 +86,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     npz_file_path = "test_points.npz"  # Path to a sample .npz file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_npz_points2d.lap"  # Path to save the LAP file
@@ -90,4 +95,4 @@ if __name__ == "__main__":
     generate_npz_from_png(png_file_path, npz_file_path)
 
     # Run the test
-    test_get_standard_points2d_lap(server, pass_code, device_id, npz_file_path, json_file_path, output_file_path)
+    test_get_standard_points2d_lap(server, pass_code, device_id, device_ip, npz_file_path, json_file_path, output_file_path)

--- a/standard_pdf.py
+++ b/standard_pdf.py
@@ -1,39 +1,39 @@
 import requests
 
-def test_get_pdf_lap(server, pass_code, device_id, device_ip, pdf_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_pdf_lap(server, pass_code, device_id, pdf_file_path, json_file_path, output_file_path, auth_code=None, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
-    Test the full-svg-lap endpoint.
+    Test the standard-pdf-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
         pdf_file_path (str): Path to the pdf file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
+        workspaceX_mm_min (float): Workspace X min in millimeters.
+        workspaceX_mm_max (float): Workspace X max in millimeters.
+        workspaceY_mm_min (float): Workspace Y min in millimeters.
+        workspaceY_mm_max (float): Workspace Y max in millimeters.
     """
     try:
         url = server + "/api/jobs/standard-pdf-lap"
-
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(pdf_file_path, "rb") as pdf_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
-                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
                 "workspaceY_mm_max": workspaceY_mm_max,
             }
+            
+            # Only include auth_code if provided
+            if auth_code:
+                data["device_auth_code"] = auth_code
             files = {
                 "pdf_file": pdf_file,
                 "json_file": json_file,
@@ -59,20 +59,22 @@ if __name__ == "__main__":
     server = "http://localhost:5005"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for device authentication.
     pdf_file_path = "test.pdf"  # Path to a sample PDF file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_pdf.lap"
+    
     # Optional: Set workspace size
     workspaceX_mm_min = -50
     workspaceX_mm_max = 50
     workspaceY_mm_min = -50
     workspaceY_mm_max = 50
+    
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
     test_get_pdf_lap(
         server=server,
         pass_code=pass_code,
         device_id=device_id,
-        device_ip=device_ip,
         pdf_file_path=pdf_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,
@@ -81,3 +83,25 @@ if __name__ == "__main__":
         workspaceY_mm_min=workspaceY_mm_min,
         workspaceY_mm_max=workspaceY_mm_max
     )
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_get_pdf_lap(
+    #         server=server,
+    #         pass_code=pass_code,
+    #         device_id=device_id,
+    #         pdf_file_path=pdf_file_path,
+    #         json_file_path=json_file_path,
+    #         output_file_path="output_pdf_with_totp.lap",
+    #         auth_code=auth_code,
+    #         workspaceX_mm_min=workspaceX_mm_min,
+    #         workspaceX_mm_max=workspaceX_mm_max,
+    #         workspaceY_mm_min=workspaceY_mm_min,
+    #         workspaceY_mm_max=workspaceY_mm_max
+    #     )
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/standard_pdf.py
+++ b/standard_pdf.py
@@ -17,7 +17,11 @@ def test_get_pdf_lap(server, pass_code, device_id, device_ip, pdf_file_path, jso
         url = server + "/api/jobs/standard-pdf-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(pdf_file_path, "rb") as pdf_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request

--- a/standard_pdf.py
+++ b/standard_pdf.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_get_pdf_lap(server, pass_code, device_access_code, pdf_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_pdf_lap(server, pass_code, device_id, pdf_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the full-svg-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         pdf_file_path (str): Path to the pdf file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -20,7 +20,7 @@ def test_get_pdf_lap(server, pass_code, device_access_code, pdf_file_path, json_
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -50,7 +50,7 @@ def test_get_pdf_lap(server, pass_code, device_access_code, pdf_file_path, json_
 if __name__ == "__main__":
     server = "http://localhost:5005"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     pdf_file_path = "test.pdf"  # Path to a sample PDF file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_pdf.lap"
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     test_get_pdf_lap(
         server=server,
         pass_code=pass_code,
-        device_access_code=device_access_code,
+        device_id=device_id,
         pdf_file_path=pdf_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,

--- a/standard_pdf.py
+++ b/standard_pdf.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_pdf_lap(server, pass_code, device_id, pdf_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_pdf_lap(server, pass_code, device_id, device_ip, pdf_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the full-svg-lap endpoint.
 
@@ -8,6 +8,7 @@ def test_get_pdf_lap(server, pass_code, device_id, pdf_file_path, json_file_path
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         pdf_file_path (str): Path to the pdf file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -15,12 +16,15 @@ def test_get_pdf_lap(server, pass_code, device_id, pdf_file_path, json_file_path
     try:
         url = server + "/api/jobs/standard-pdf-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(pdf_file_path, "rb") as pdf_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -51,6 +55,7 @@ if __name__ == "__main__":
     server = "http://localhost:5005"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for device authentication.
     pdf_file_path = "test.pdf"  # Path to a sample PDF file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_pdf.lap"
@@ -63,6 +68,7 @@ if __name__ == "__main__":
         server=server,
         pass_code=pass_code,
         device_id=device_id,
+        device_ip=device_ip,
         pdf_file_path=pdf_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,

--- a/standard_png.py
+++ b/standard_png.py
@@ -1,7 +1,7 @@
 import requests
 import json
 
-def test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, transform_params, output_file_path):
+def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path, auth_code=None):
     """
     Test the standard-png-lap endpoint.
 
@@ -9,30 +9,26 @@ def test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
         output_file_path (str): Path to save the output file.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
     """
     try:
         url = f"{server}/api/jobs/standard-png-lap"
-
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
-                "device_auth_code": device_auth_code,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
+            
+            # Only include auth_code if provided
+            if auth_code:
+                data["device_auth_code"] = auth_code
             files = {
                 "png_file": png_file,
                 "json_file": json_file,
@@ -60,11 +56,21 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     transform_params = [0.1, 0.0, 0.0, 0.1, 20.0, 15.25]  # Example transform parameters
     output_file_path = "output_standard_png.lap"  # Path to save the LAP file
 
-    # Run the test
-    test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, transform_params, output_file_path)
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
+    test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path)
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, "output_standard_png_with_totp.lap", auth_code=auth_code)
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/standard_png.py
+++ b/standard_png.py
@@ -19,7 +19,11 @@ def test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_
         url = f"{server}/api/jobs/standard-png-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request

--- a/standard_png.py
+++ b/standard_png.py
@@ -1,7 +1,7 @@
 import requests
 import json
 
-def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path):
+def test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, transform_params, output_file_path):
     """
     Test the standard-png-lap endpoint.
 
@@ -9,6 +9,7 @@ def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -17,12 +18,15 @@ def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_
     try:
         url = f"{server}/api/jobs/standard-png-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
             files = {
@@ -52,10 +56,11 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     transform_params = [0.1, 0.0, 0.0, 0.1, 20.0, 15.25]  # Example transform parameters
     output_file_path = "output_standard_png.lap"  # Path to save the LAP file
 
     # Run the test
-    test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path)
+    test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, transform_params, output_file_path)

--- a/standard_png.py
+++ b/standard_png.py
@@ -1,14 +1,14 @@
 import requests
 import json
 
-def test_get_standard_png_lap(server, pass_code, device_access_code, png_file_path, json_file_path, transform_params, output_file_path):
+def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path):
     """
     Test the standard-png-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -22,7 +22,7 @@ def test_get_standard_png_lap(server, pass_code, device_access_code, png_file_pa
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
             files = {
@@ -51,11 +51,11 @@ if __name__ == "__main__":
     # Define test parameters
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     transform_params = [0.1, 0.0, 0.0, 0.1, 20.0, 15.25]  # Example transform parameters
     output_file_path = "output_standard_png.lap"  # Path to save the LAP file
 
     # Run the test
-    test_get_standard_png_lap(server, pass_code, device_access_code, png_file_path, json_file_path, transform_params, output_file_path)
+    test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path)

--- a/standard_png_center_rotate.py
+++ b/standard_png_center_rotate.py
@@ -3,7 +3,7 @@ import json
 from PIL import Image  # Add Pillow import
 import math # Add math import
 
-def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path):
+def test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, transform_params, output_file_path):
     """
     Test the standard-png-lap endpoint.
 
@@ -11,6 +11,7 @@ def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -19,12 +20,15 @@ def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_
     try:
         url = f"{server}/api/jobs/standard-png-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
             files = {
@@ -54,6 +58,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "_your_passcode_here_" #Pass code for authentication. -> get the user passcode from the website ensure you get it from the same server above eg https://beta.fslaser.com
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     #png_file_path = "alice.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
@@ -114,4 +119,4 @@ if __name__ == "__main__":
     output_file_path = "output_standard_png.lap"  # Path to save the LAP file
 
     # Run the test
-    test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path)
+    test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_path, json_file_path, transform_params, output_file_path)

--- a/standard_png_center_rotate.py
+++ b/standard_png_center_rotate.py
@@ -3,14 +3,14 @@ import json
 from PIL import Image  # Add Pillow import
 import math # Add math import
 
-def test_get_standard_png_lap(server, pass_code, device_access_code, png_file_path, json_file_path, transform_params, output_file_path):
+def test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path):
     """
     Test the standard-png-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         png_file_path (str): Path to the PNG file.
         json_file_path (str): Path to the JSON file.
         transform_params (list): List of transformation parameters [sx, shx, shy, sy, tx, ty].
@@ -24,7 +24,7 @@ def test_get_standard_png_lap(server, pass_code, device_access_code, png_file_pa
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "transform_params": json.dumps(transform_params),  # Convert to JSON-like string
             }
             files = {
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # Define test parameters
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "_your_passcode_here_" #Pass code for authentication. -> get the user passcode from the website ensure you get it from the same server above eg https://beta.fslaser.com
-    device_access_code = "_your_device_code_here_" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     png_file_path = "test.png"  # Path to a sample PNG file
     #png_file_path = "alice.png"  # Path to a sample PNG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
@@ -114,4 +114,4 @@ if __name__ == "__main__":
     output_file_path = "output_standard_png.lap"  # Path to save the LAP file
 
     # Run the test
-    test_get_standard_png_lap(server, pass_code, device_access_code, png_file_path, json_file_path, transform_params, output_file_path)
+    test_get_standard_png_lap(server, pass_code, device_id, png_file_path, json_file_path, transform_params, output_file_path)

--- a/standard_png_center_rotate.py
+++ b/standard_png_center_rotate.py
@@ -21,7 +21,11 @@ def test_get_standard_png_lap(server, pass_code, device_id, device_ip, png_file_
         url = f"{server}/api/jobs/standard-png-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(png_file_path, "rb") as png_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request

--- a/standard_svg.py
+++ b/standard_svg.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_standard_svg_lap(server, pass_code, device_id, svg_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_standard_svg_lap(server, pass_code, device_id, device_ip, svg_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the standard-svg-lap endpoint.
 
@@ -8,6 +8,7 @@ def test_get_standard_svg_lap(server, pass_code, device_id, svg_file_path, json_
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
+        device_ip (str): Device IP for authentication.
         svg_file_path (str): Path to the svg file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -15,12 +16,15 @@ def test_get_standard_svg_lap(server, pass_code, device_id, svg_file_path, json_
     try:
         url = server + "/api/jobs/standard-svg-lap"
 
+        # get the device auth code from the {device_ip}/2fa
+        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
         # Open the files to upload
         with open(svg_file_path, "rb") as svg_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
+                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -51,6 +55,7 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
+    device_ip = "192.168.1.100" #Device IP for authentication.
     svg_file_path = "test.svg"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_standard_svg.lap"
@@ -63,6 +68,7 @@ if __name__ == "__main__":
         server=server,
         pass_code=pass_code,
         device_id=device_id,
+        device_ip=device_ip,
         svg_file_path=svg_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,

--- a/standard_svg.py
+++ b/standard_svg.py
@@ -1,13 +1,13 @@
 import requests
 
-def test_get_standard_svg_lap(server, pass_code, device_access_code, svg_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_standard_svg_lap(server, pass_code, device_id, svg_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the standard-svg-lap endpoint.
 
     Args:
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
-        device_access_code (str): Device access code for authentication.
+        device_id (str): Device ID for authentication.
         svg_file_path (str): Path to the svg file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
@@ -20,7 +20,7 @@ def test_get_standard_svg_lap(server, pass_code, device_access_code, svg_file_pa
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
-                "device_access_code": device_access_code,
+                "device_id": device_id,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
@@ -50,7 +50,7 @@ def test_get_standard_svg_lap(server, pass_code, device_access_code, svg_file_pa
 if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
-    device_access_code = "Chastity:Lasso:87" #Device access code for device authentication. -> get the device access code from the device touchscreen
+    device_id = "AE356O3E89D" #Device ID for device authentication.
     svg_file_path = "test.svg"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_standard_svg.lap"
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     test_get_standard_svg_lap(
         server=server,
         pass_code=pass_code,
-        device_access_code=device_access_code,
+        device_id=device_id,
         svg_file_path=svg_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,

--- a/standard_svg.py
+++ b/standard_svg.py
@@ -1,6 +1,6 @@
 import requests
 
-def test_get_standard_svg_lap(server, pass_code, device_id, device_ip, svg_file_path, json_file_path, output_file_path, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
+def test_get_standard_svg_lap(server, pass_code, device_id, svg_file_path, json_file_path, output_file_path, auth_code=None, workspaceX_mm_min=0, workspaceX_mm_max=0, workspaceY_mm_min=0, workspaceY_mm_max=0):
     """
     Test the standard-svg-lap endpoint.
 
@@ -8,32 +8,32 @@ def test_get_standard_svg_lap(server, pass_code, device_id, device_ip, svg_file_
         server (str): The server URL.
         pass_code (str): Pass code for authentication.
         device_id (str): Device ID for authentication.
-        device_ip (str): Device IP for authentication.
         svg_file_path (str): Path to the svg file.
         json_file_path (str): Path to the JSON file.
         output_file_path (str): Path to save the output file.
+        auth_code (str, optional): Device authentication code. If not provided, will be omitted (for same-network requests).
+        workspaceX_mm_min (float): Workspace X min in millimeters.
+        workspaceX_mm_max (float): Workspace X max in millimeters.
+        workspaceY_mm_min (float): Workspace Y min in millimeters.
+        workspaceY_mm_max (float): Workspace Y max in millimeters.
     """
     try:
         url = server + "/api/jobs/standard-svg-lap"
-
-        # get the device auth code from the {device_ip}/2fa
-        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
-        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
-        if not totp_response.get("success"):
-            raise Exception(f"Failed to get TOTP: {totp_response}")
-        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(svg_file_path, "rb") as svg_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request
             data = {
                 "pass_code": pass_code,
                 "device_id": device_id,
-                "device_auth_code": device_auth_code,
                 "workspaceX_mm_min": workspaceX_mm_min,
                 "workspaceX_mm_max": workspaceX_mm_max,
                 "workspaceY_mm_min": workspaceY_mm_min,
                 "workspaceY_mm_max": workspaceY_mm_max,
             }
+            
+            # Only include auth_code if provided
+            if auth_code:
+                data["device_auth_code"] = auth_code
             files = {
                 "svg_file": svg_file,
                 "json_file": json_file,
@@ -59,20 +59,22 @@ if __name__ == "__main__":
     server = "https://beta.fslaser.com"  # Replace with your server URL
     pass_code = "Pork_Hacking_98" #Pass code for authentication. -> get the user passcode from the website
     device_id = "AE356O3E89D" #Device ID for device authentication.
-    device_ip = "192.168.1.100" #Device IP for authentication.
     svg_file_path = "test.svg"  # Path to a sample SVG file
     json_file_path = "color_settings.json"  # Path to a sample JSON file
     output_file_path = "output_standard_svg.lap"
+    
     # Optional: Set workspace size
     workspaceX_mm_min = -50
     workspaceX_mm_max = 50
     workspaceY_mm_min = -50
     workspaceY_mm_max = 50
+    
+    # Option 1: Same network - no auth code needed
+    print("Testing without auth code (same network)...")
     test_get_standard_svg_lap(
         server=server,
         pass_code=pass_code,
         device_id=device_id,
-        device_ip=device_ip,
         svg_file_path=svg_file_path,
         json_file_path=json_file_path,
         output_file_path=output_file_path,
@@ -81,3 +83,25 @@ if __name__ == "__main__":
         workspaceY_mm_min=workspaceY_mm_min,
         workspaceY_mm_max=workspaceY_mm_max
     )
+    
+    # Option 2: Using TOTP auth code (uncomment if needed)
+    # from auth_code_grabber import get_device_auth_code
+    # print("Testing with auth code (TOTP)...")
+    # try:
+    #     device_ip = "192.168.1.100"  # Define device IP only when using TOTP
+    #     auth_code = get_device_auth_code(device_ip)
+    #     test_get_standard_svg_lap(
+    #         server=server,
+    #         pass_code=pass_code,
+    #         device_id=device_id,
+    #         svg_file_path=svg_file_path,
+    #         json_file_path=json_file_path,
+    #         output_file_path="output_standard_svg_with_totp.lap",
+    #         auth_code=auth_code,
+    #         workspaceX_mm_min=workspaceX_mm_min,
+    #         workspaceX_mm_max=workspaceX_mm_max,
+    #         workspaceY_mm_min=workspaceY_mm_min,
+    #         workspaceY_mm_max=workspaceY_mm_max
+    #     )
+    # except Exception as e:
+    #     print(f"Could not use TOTP authentication: {e}")

--- a/standard_svg.py
+++ b/standard_svg.py
@@ -17,7 +17,11 @@ def test_get_standard_svg_lap(server, pass_code, device_id, device_ip, svg_file_
         url = server + "/api/jobs/standard-svg-lap"
 
         # get the device auth code from the {device_ip}/2fa
-        device_auth_code = requests.get(f"http://{device_ip}/2fa").json()["totp"]
+        # Note: Both HTTP and HTTPS work, but HTTPS requires verify=False to disable SSL verification
+        totp_response = requests.post(f"https://{device_ip}/2fa", verify=False).json()
+        if not totp_response.get("success"):
+            raise Exception(f"Failed to get TOTP: {totp_response}")
+        device_auth_code = totp_response["totp"]["totp"]
         # Open the files to upload
         with open(svg_file_path, "rb") as svg_file, open(json_file_path, "rb") as json_file:
             # Prepare the data and files for the POST request


### PR DESCRIPTION
# 🚨 IMPORTANT: Authentication Method Change Notice

## ⚠️ Breaking Change Coming in 2 Weeks

**Effective Date**: October 9, 2025

We are updating our API authentication system to improve security and ensure proper device connectivity. This change affects how you authenticate with the Re4 Job File API.

## 📋 What's Changing

### **Current Behavior (Still Works for 2 More Weeks)**
- ✅ API works with access codes from any network
- ✅ Machine can be offline when using stored access codes
- ✅ Access codes remain valid for extended periods

### **New Behavior (Effective in 2 Weeks)**
- 🔒 **Option 1**: API client must be on the **same local network** as the device (no auth code needed, device doesn't need to be currently online as long as it was on this network when it last went offline)
- 🔒 **Option 2**: Get a **fresh one-time auth code** from the device (machine must be online for you to read code)
- ⏰ **Important**: One-time auth codes expire every **5 minutes**

## 🎯 Why This Change?

This update ensures:
- **Better Security**: Prevents unauthorized access from remote networks
- **Device Connectivity**: Ensures the machine is actually online and responsive
- **Real-time Validation**: Fresh authentication codes prevent stale access

## 📝 What You Need to Do

### **For Same-Network Users (Recommended)**
- ✅ **No changes needed** - remove `device_auth_code` from your API calls and replace with `device_id`
- ✅ **Device doesn't need to be currently online** - as long as it was on this network when it last went offline
- ✅ This is the **preferred method** going forward

### **For Remote/Cross-Network Users**
- 🔄 **Update your workflow** to read fresh `auth_code` from device every 5 minutes
- 🔄 **Add auth_code to api parameters** when making API calls, add `auth_code`
- 🔄 **Use the new `auth_code_grabber.py`** utility for automated code retrieval

### **For Fail-Safe Option**
- 🔄 **In case option 1 error out even on same network** you may use `auth_code_grabber.py` to grab auth_code from device using device's ip (requires to be on same network). This is a fail-safe in case something is wrong with option 1.

## 🛠️ Migration Guide

### **Before (Old Method)**
```python
# Old way - worked from anywhere, machine could be offline
device_auth_code = "stored_code_from_anywhere"
```

### **After (New Method)**

#### **Option 1: Same Network (Recommended)**
```python
# New way - same network, no auth code needed
# Just omit device_auth_code parameter entirely
data = {
    "pass_code": pass_code,
    "device_id": device_id,
    # device_auth_code omitted - API auto-detects same network
}
```

#### **Option 2: Fresh TOTP Code**
```python
# New way - get fresh code every 5 minutes
data = {
    "pass_code": pass_code,
    "device_id": device_id,
    "device_auth_code": auth_code,  # Fresh code required
}
```

## 📅 Timeline

- **Now - October 9, 2025**: Old method still works (grace period)
- **October 9, 2025**: New authentication enforced
- **After enforcement**: Old method will be rejected

## 🔧 Updated Scripts

All example scripts have been updated to support both methods:
- `standard_pdf.py`, `standard_svg.py`, `standard_png.py`, etc.
- `api_run_lap_job.py`, `api_stop_job.py`, `api_query_job_status.py`, etc.
- New utility: `auth_code_grabber.py`

## ❓ Questions?

If you have questions about this change:
1. Check the updated `README.md` for detailed documentation
2. Review the updated example scripts
3. Test the new authentication methods during the grace period
4. Post issues here in this Github repo if you need assistance with migration

## 🚀 Action Required

**Please update your applications within the next 2 weeks** to avoid service interruption. The old authentication method will stop working after the enforcement date.

---

*This notice was posted on September 25, 2025. Please ensure your systems are updated before October 9, 2025.*